### PR TITLE
Fix YAML structure and streamline documentation formatting

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,11 +1,3 @@
-______________________________________________________________________
-
-hide:
-
-- navigation
-
-______________________________________________________________________
-
 <style>
 .md-content .md-typeset h1 { display: none; }
 </style>
@@ -96,7 +88,7 @@ Process completed successfully
         description: "Web server IP address"
         ip_netmask: "192.168.1.100/32"
         folder: "Texas"
-        tag: ["Web", "Production"]
+        tag: [ "Web", "Production" ]
         state: "present"
       register: address_result
 
@@ -111,7 +103,7 @@ Process completed successfully
         description: "DNS server FQDN"
         fqdn: "dns.example.com"
         folder: "Texas"
-        tag: ["DNS", "Infrastructure"]
+        tag: [ "DNS", "Infrastructure" ]
         state: "present"
 
     - name: Create a security rule using these addresses
@@ -119,12 +111,12 @@ Process completed successfully
         provider: "{{ provider }}"
         name: "Allow_Web_to_DNS"
         description: "Allow web servers to access DNS"
-        source_zone: ["trust"]
-        destination_zone: ["trust"]
-        source_address: ["Web_Server"]
-        destination_address: ["DNS_Server"]
-        application: ["dns"]
-        service: ["application-default"]
+        source_zone: [ "trust" ]
+        destination_zone: [ "trust" ]
+        source_address: [ "Web_Server" ]
+        destination_address: [ "DNS_Server" ]
+        application: [ "dns" ]
+        service: [ "application-default" ]
         action: "allow"
         folder: "Texas"
         state: "present"
@@ -142,10 +134,10 @@ ______________________________________________________________________
 - **Complete Configuration Management**: Create, update, and delete SCM configuration objects
 - **Idempotent Operations**: Safe to run multiple times with the same expected outcome
 - **Categorized Modules**:
-  - Network Objects (Address, Service, Tag)
-  - Network Configuration (Zones, VPN, Routing)
-  - Security Services (Rules, Profiles)
-  - Deployment (Remote Networks, Service Connections)
+    - Network Objects (Address, Service, Tag)
+    - Network Configuration (Zones, VPN, Routing)
+    - Security Services (Rules, Profiles)
+    - Deployment (Remote Networks, Service Connections)
 - **Roles for Common Tasks**: Pre-built roles for bootstrapping and configuration deployment
 - **Inventory Plugin**: Dynamically build inventory from SCM
 - **Integration with SCM SDK**: Reliable API interactions with proper error handling

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -111,12 +111,6 @@ nav:
               - HIP Object Info: collection/modules/hip_object_info.md
               - HIP Profile: collection/modules/hip_profile.md
               - HIP Profile Info: collection/modules/hip_profile_info.md
-              - Service: collection/modules/service.md
-              - Service Info: collection/modules/service_info.md
-              - Service Group: collection/modules/service_group.md
-              - Service Group Info: collection/modules/service_group_info.md
-              - Tag: collection/modules/tag.md
-              - Tag Info: collection/modules/tag_info.md
               - HTTP Server Profiles: collection/modules/http_server_profiles.md
               - HTTP Server Profiles Info: collection/modules/http_server_profiles_info.md
               - Log Forwarding Profile: collection/modules/log_forwarding_profile.md
@@ -125,8 +119,14 @@ nav:
               - Quarantined Devices Info: collection/modules/quarantined_devices_info.md
               - Region: collection/modules/region.md
               - Region Info: collection/modules/region_info.md
+              - Service: collection/modules/service.md
+              - Service Info: collection/modules/service_info.md
+              - Service Group: collection/modules/service_group.md
+              - Service Group Info: collection/modules/service_group_info.md
               - Syslog Server Profiles: collection/modules/syslog_server_profiles.md
               - Syslog Server Profiles Info: collection/modules/syslog_server_profiles_info.md
+              - Tag: collection/modules/tag.md
+              - Tag Info: collection/modules/tag_info.md
           - Network Configuration:
               - Security Zone: collection/modules/security_zone.md
               - IKE Crypto Profile: collection/modules/ike_crypto_profile.md


### PR DESCRIPTION
Reordered mkdocs navigation items to maintain logical grouping and address redundancy. Adjusted formatting in index.md for consistent tag style and improved readability. Removed unnecessary sections and styling, ensuring cleaner documentation output.